### PR TITLE
Fixed bug: 'npm is not recognized in dev script on Windows platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "nodemon --watch src --exec 'npm run dev:build && npm run dev:exec'",
+    "dev": "nodemon --watch src --exec \"npm run dev:build && npm run dev:exec\"",
     "dev:build": "cross-env NODE_ENV=development webpack",
     "dev:exec": "node dist/index",
     "build": "cross-env NODE_ENV=production webpack"


### PR DESCRIPTION
Running `npm run dev` on Windows, the CMD / Powershell aborted with an error message: ''npm' is not recognized as an internal or external command, operable program or batch file.

Replace the single quotes with escaped double quotes would work as expected.